### PR TITLE
Fix container killing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -qq update && \
 RUN mkdir -p /etc/services.d/nginx
 
 COPY service-nginx-start /etc/services.d/nginx/run
-#COPY service-nginx-stop  /etc/services.d/nginx/finish
+COPY service-nginx-stop  /etc/services.d/nginx/finish
 COPY proxy.conf          /etc/nginx/sites-enabled/default
 
 # ENV variables to replace conf file from Galaxy

--- a/monitor_traffic.sh
+++ b/monitor_traffic.sh
@@ -18,7 +18,7 @@ while true; do
         # this means we can delete everything from /import/
         if [[ "$DEBUG" == "false" ]];
         then
-            rm -rf /import/;
+            rm -rf /import/*;
         fi
     fi
 

--- a/monitor_traffic.sh
+++ b/monitor_traffic.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
-# Take the netstat output the estimate if the client is still connected to
+# Take the netstat output to estimate if the client is still connected to
 # the RStudio server. The 'CLOSE_WAIT' state will be ignored. It
-# Indicates that the server has received the first FIN signal from the client
+# indicates that the server has received the first FIN signal from the client
 # and the connection is in the process of being closed. But that can never happen.
 # For some reason there are a few connections open that do not relate the
 # client that needs to be connected over the port :80 If we do not have a
 # connection open from port 80, kill the server and herewith the docker container.
 
+# For RStudio there is typically one ESTABLISHED connection (get_events HTTP 50s long request)
+# and one TIME_WAIT (probably the previous get_events HTTP request)
+
 while true; do
     sleep 240
 
-    if [ `netstat -t | grep -v CLOSE_WAIT | grep ':80' | wc -l` -lt 3 ]
+    if [ `netstat -t | grep -v CLOSE_WAIT | grep ':80' | wc -l` -lt 2 ]
     then
         pkill nginx
         # We will create new history elements with all data that is relevant,

--- a/service-nginx-stop
+++ b/service-nginx-stop
@@ -1,0 +1,3 @@
+#!/usr/bin/execlineb -S0
+
+s6-svscanctl -t /var/run/s6/services


### PR DESCRIPTION
A fix for #25
It's not yet ready as now the container gets killed to early = monitor_traffic.sh thinks that user is gone when he is not
I guess the `< 3` test should be changed at https://github.com/erasche/docker-rstudio-notebook/blob/19.05/monitor_traffic.sh#L14, will look into it (I guess 3 was a valid value at some point!?)