### PR TITLE
Fix lack of import dir accessibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN Rscript /tmp/packages/gx.R
 RUN Rscript /tmp/packages/other.R
 RUN Rscript /tmp/packages/bioconda.R
 RUN pip install git+https://github.com/bgruening/galaxy_ie_helpers.git@master
-RUN chmod 777 /import/
+RUN chmod -R 777 /import/ /home/rstudio && ln -s /import /home/rstudio/import
 
 # Must happen later, otherwise GalaxyConnector is loaded by default, and fails,
 # preventing ANY execution

--- a/Rprofile.site
+++ b/Rprofile.site
@@ -1,3 +1,4 @@
 library("GalaxyConnector")
 .First <- function() cat("\n   Welcome to the Galaxy R Interactive Environment!\n\nThe convenience functions gx_put() and gx_get() are available to you to interact with your current Galaxy history. You can save your workspace with gx_save(). \n\nFor example, gx_get(42) will fetch dataset 42 from your history and return the file location \n\nSome packages are pre-installed for you; RCurl, XML, shiny, ggvis, dplyr, tidyr, ggplot2, reshape2, RODBC, Bioconductor core packages, edgeR, Gviz, Rgraphviz, limma, DESeq2, cummeRbund, affay, Rsamtools")
 options(encoding = "UTF-8")
+setwd("import")


### PR DESCRIPTION
@erasche this is a follow up to our conversation in https://github.com/erasche/docker-rstudio-notebook/issues/24

I found a turn around that imply a minimum code change

basically
- the rstudio.ini.sample file should contain `use_volumes = False`. This is to reflect the abandon of the VOLUME statement in the Docker file

- The docker image should be rebuilt with
`RUN chmod -R 777 /import/ /home/rstudio && ln -s /import /home/rstudio/import` in the Dockerfile and `setwd("import")` in the Rprofile.site file.

Thus, the ie user finds an Rstudio interface that is not super pretty (with still contains this useless kinematic folder and shows a closed import folder), but apart that, it is workable for a reasonably skilled R user.

Let me know your thoughts 