### PR TITLE
fix  'import' path in Rprofile.site file

### DIFF
--- a/Rprofile.site
+++ b/Rprofile.site
@@ -1,4 +1,4 @@
 library("GalaxyConnector")
 .First <- function() cat("\n   Welcome to the Galaxy R Interactive Environment!\n\nThe convenience functions gx_put() and gx_get() are available to you to interact with your current Galaxy history. You can save your workspace with gx_save(). \n\nFor example, gx_get(42) will fetch dataset 42 from your history and return the file location \n\nSome packages are pre-installed for you; RCurl, XML, shiny, ggvis, dplyr, tidyr, ggplot2, reshape2, RODBC, Bioconductor core packages, edgeR, Gviz, Rgraphviz, limma, DESeq2, cummeRbund, affay, Rsamtools")
 options(encoding = "UTF-8")
-setwd("import")
+setwd("/import")


### PR DESCRIPTION
This correction is required to allow galaxy rstudio users installing new packages in their environment.  The resulting docker container artbio/docker-rstudio-notebook was successfully [built](https://hub.docker.com/repository/registry-1.docker.io/artbio/rstudio-notebook/builds/ca840638-09f6-48d6-bc98-e401634da99b) and tested 