### PR TITLE
chmod Conda after updating and installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /opt/ && \
     echo "conda activate base" >> "$CONDA_PATH/etc/profile.d/conda.sh" && \
     ln -s "$CONDA_PATH/etc/profile.d/conda.sh" /etc/profile.d/conda.sh && \
     echo ". $CONDA_PATH/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    chmod 777 ${CONDA_PATH} -R && \
+    chown -Rh rstudio:rstudio ${CONDA_PATH} && \
     chmod 777 /tmp
 
 COPY requirements.txt /tmp/requirements.txt
@@ -42,7 +42,8 @@ USER rstudio
 RUN /opt/miniconda/bin/conda update -n base --yes conda \
     && /opt/miniconda/bin/conda config --append channels bioconda \
     && /opt/miniconda/bin/conda install --file /tmp/requirements.txt r-base=${R_VERSION} -y \
-    && /opt/miniconda/bin/conda clean -a
+    && /opt/miniconda/bin/conda clean -a \
+    && chmod 777 ${CONDA_PATH} -R
 
 USER root
 


### PR DESCRIPTION
Otherwise, not everything in conda is writable, causing install failures if you change the container user from the default (which I assume is whole reason for `chmod 777` in the first place).